### PR TITLE
Issue 25

### DIFF
--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '*.adoc'        # Ignores .adoc files at the root of the repository
+      - '*.md'          # Ignores .md files at the root of the repository
+      - '**/*.md'       # Ignores .md files within subdirectories
 jobs:
   linux-pack-build:
     name: Linux - Pack CLI build

--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -7,7 +7,6 @@ on:
       - main
 jobs:
   linux-pack-build:
-    if: contains(github.event.head_commit.message, 'pack_test')
     name: Linux - Pack CLI build
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         builder-image: [ 'paketobuildpacks/builder-jammy-tiny:0.0.175' ]
+        pack_cli_version: [ 'v0.30.0-rc1' ]
     steps:
       - uses: actions/checkout@v3
 
@@ -23,11 +24,9 @@ jobs:
         uses: Sgitario/setup-container-registry@v1
 
       - name: Install Pack
-        # Version installed: 0.29 (June 2023)
+        # Version needed: >= 0.30 (Aug 2023)
         run: |
-          sudo add-apt-repository ppa:cncf-buildpacks/pack-cli
-          sudo apt-get update
-          sudo apt-get install pack-cli
+          curl -sSL "https://github.com/buildpacks/pack/releases/download/${{ matrix.pack_cli_version }}/${{ matrix.pack_cli_version }}-linux.tgz" | sudo tar -C /usr/local/bin/ --no-same-owner -xzv pack
 
       - name: Test Quarkus Getting Started using ${{ matrix.builder-image }}
         run: |

--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        builder-image: [ 'paketobuildpacks/builder:tiny' ]
+        builder-image: [ 'paketobuildpacks/builder-jammy-tiny:0.0.175' ]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Pack
         # Version needed: >= 0.30 (Aug 2023)
         run: |
-          curl -sSL "https://github.com/buildpacks/pack/releases/download/${{ matrix.pack_cli_version }}/${{ matrix.pack_cli_version }}-linux.tgz" | sudo tar -C /usr/local/bin/ --no-same-owner -xzv pack
+          curl -sSL "https://github.com/buildpacks/pack/releases/download/${{ matrix.pack_cli_version }}/pack-${{ matrix.pack_cli_version }}-linux.tgz" | sudo tar -C /usr/local/bin/ --no-same-owner -xzv pack
 
       - name: Test Quarkus Getting Started using ${{ matrix.builder-image }}
         run: |

--- a/.github/workflows/pack_nodejs.yaml
+++ b/.github/workflows/pack_nodejs.yaml
@@ -80,9 +80,9 @@ jobs:
           version = "0.0.1"
           
           [stack]
-          id = "ubi8-paketo"
-          build-image = "quay.io/midawson/ubi8-paketo-build"
-          run-image = "quay.io/midawson/ubi8-paketo-run"
+          id = "io.buildpacks.stacks.ubi8"
+          build-image = "paketocommunity/build-ubi-base"
+          run-image = "paketocommunity/run-ubi-base"
           EOF
           
           pack builder create $BUILDER_IMAGE --config $BUILDER_PATH --publish

--- a/.github/workflows/pack_nodejs.yaml
+++ b/.github/workflows/pack_nodejs.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '*.adoc'        # Ignores .adoc files at the root of the repository
+      - '*.md'          # Ignores .md files at the root of the repository
+      - '**/*.md'       # Ignores .md files within subdirectories
 jobs:
   linux-pack-build:
     name: Linux - Pack CLI build

--- a/.github/workflows/pack_nodejs.yaml
+++ b/.github/workflows/pack_nodejs.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pack_cli_version: [ 'v0.30.0-pre2' ]
+        pack_cli_version: [ 'v0.30.0-rc1' ]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/pack_nodejs.yaml
+++ b/.github/workflows/pack_nodejs.yaml
@@ -7,7 +7,6 @@ on:
       - main
 jobs:
   linux-pack-build:
-    if: contains(github.event.head_commit.message, 'pack_nodejs_test')
     name: Linux - Pack CLI build
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pack_nodejs.yaml
+++ b/.github/workflows/pack_nodejs.yaml
@@ -53,7 +53,7 @@ jobs:
           version = "1.4.0"
           
           [lifecycle]
-          version = "0.17.0-pre.2"
+          version = "0.17.0"
           
           [[order]]
           [[order.group]]

--- a/.github/workflows/pack_nodejs.yaml
+++ b/.github/workflows/pack_nodejs.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # Reverted v0.30.0-rc1 to v0.30.0-pre2 as we got
         # [detector] failed to satisfy "node" dependency version constraint "18 || 16": no compatible versions on "ubi8-paketo" stack. Supported versions are: []
-        pack_cli_version: [ 'v0.30.0-pre2' ]
+        pack_cli_version: [ 'v0.30.0-rc1' ]
     steps:
       - uses: actions/checkout@v3
 
@@ -62,7 +62,7 @@ jobs:
           # Changed 0.17.0 -> 0.17.0-pre.2
           # as we got as error
           # [detector] failed to satisfy "node" dependency version constraint "18 || 16": no compatible versions on "ubi8-paketo" stack. Supported versions are: []
-          version = "0.17.0-pre.2"
+          version = "0.17.0"
           
           [[order]]
           [[order.group]]

--- a/.github/workflows/pack_nodejs.yaml
+++ b/.github/workflows/pack_nodejs.yaml
@@ -62,7 +62,7 @@ jobs:
           # Changed 0.17.0 -> 0.17.0-pre.2
           # as we got as error
           # [detector] failed to satisfy "node" dependency version constraint "18 || 16": no compatible versions on "ubi8-paketo" stack. Supported versions are: []
-          version = "0.17.0"
+          version = "0.17.0-pre.2"
           
           [[order]]
           [[order.group]]

--- a/.github/workflows/pack_nodejs.yaml
+++ b/.github/workflows/pack_nodejs.yaml
@@ -80,7 +80,7 @@ jobs:
           
           echo "Build the nodejs app"
           git clone https://github.com/nodeshift-starters/nodejs-rest-http.git
-          pack build $CONTAINER_IMAGE --path ./nodejs-rest-http --env BP_NODE_VERSION="~16" --builder $BUILDER_IMAGE --network host -v
+          pack build $CONTAINER_IMAGE --path ./nodejs-rest-http --builder $BUILDER_IMAGE --network host -v
           
           echo "Run the nodejs http application & tst ..."
           .github/testNodeHello.sh $CONTAINER_NAME $CONTAINER_IMAGE

--- a/.github/workflows/pack_nodejs.yaml
+++ b/.github/workflows/pack_nodejs.yaml
@@ -61,14 +61,13 @@ jobs:
           version = "1.4.0"
           
           [[extensions]]
-          id = "redhat-runtimes/nodejs"
+          id = "paketo-community/ubi-nodejs-extension"
           version = "0.0.1"
-          uri = "https://github.com/paketo-community/ubi-nodejs-extension/archive/main.tar.gz"
-          #uri = "file:///${{ github.workspace }}/ubi-nodejs-extension"
+          uri = "file:///${{ github.workspace }}/ubi-nodejs-extension"
           
           [[order-extensions]]
           [[order-extensions.group]]
-          id = "redhat-runtimes/nodejs"
+          id = "paketo-community/ubi-nodejs-extension"
           version = "0.0.1"
           
           [stack]

--- a/.github/workflows/pack_nodejs.yaml
+++ b/.github/workflows/pack_nodejs.yaml
@@ -57,7 +57,10 @@ jobs:
           version = "1.8.0"
           
           [lifecycle]
-          version = "0.17.0"
+          # Changed 0.17.0 -> 0.17.0-pre.2
+          # as we got as error
+          # [detector] failed to satisfy "node" dependency version constraint "18 || 16": no compatible versions on "ubi8-paketo" stack. Supported versions are: []
+          version = "0.17.0-pre.2"
           
           [[order]]
           [[order.group]]

--- a/.github/workflows/pack_nodejs.yaml
+++ b/.github/workflows/pack_nodejs.yaml
@@ -63,7 +63,8 @@ jobs:
           [[extensions]]
           id = "redhat-runtimes/nodejs"
           version = "0.0.1"
-          uri = "file:///${{ github.workspace }}/ubi-nodejs-extension"
+          uri = "https://github.com/paketo-community/ubi-nodejs-extension/archive/main.tar.gz"
+          #uri = "file:///${{ github.workspace }}/ubi-nodejs-extension"
           
           [[order-extensions]]
           [[order-extensions.group]]

--- a/.github/workflows/pack_nodejs.yaml
+++ b/.github/workflows/pack_nodejs.yaml
@@ -62,7 +62,7 @@ jobs:
           # Changed 0.17.0 -> 0.17.0-pre.2
           # as we got as error
           # [detector] failed to satisfy "node" dependency version constraint "18 || 16": no compatible versions on "ubi8-paketo" stack. Supported versions are: []
-          version = "0.17.0-pre.2"
+          version = "0.17.0"
           
           [[order]]
           [[order.group]]

--- a/.github/workflows/pack_nodejs.yaml
+++ b/.github/workflows/pack_nodejs.yaml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pack_cli_version: [ 'v0.30.0-rc1' ]
+        # Reverted v0.30.0-rc1 to v0.30.0-pre2 as we got
+        # [detector] failed to satisfy "node" dependency version constraint "18 || 16": no compatible versions on "ubi8-paketo" stack. Supported versions are: []
+        pack_cli_version: [ 'v0.30.0-pre2' ]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/pack_nodejs.yaml
+++ b/.github/workflows/pack_nodejs.yaml
@@ -49,8 +49,8 @@ jobs:
           description = "Sample builder that uses ubi Node.js extension to support Node.js apps"
   
           [[buildpacks]]
-          uri = "docker://gcr.io/paketo-buildpacks/nodejs:1.4.0"
-          version = "1.4.0"
+          uri = "docker://gcr.io/paketo-buildpacks/nodejs:1.8.0"
+          version = "1.8.0"
           
           [lifecycle]
           version = "0.17.0"
@@ -58,7 +58,7 @@ jobs:
           [[order]]
           [[order.group]]
           id = "paketo-buildpacks/nodejs"
-          version = "1.4.0"
+          version = "1.8.0"
           
           [[extensions]]
           id = "paketo-community/ubi-nodejs-extension"
@@ -80,7 +80,7 @@ jobs:
           
           echo "Build the nodejs app"
           git clone https://github.com/nodeshift-starters/nodejs-rest-http.git
-          pack build $CONTAINER_IMAGE --path ./nodejs-rest-http --env BP_NODE_VERSION=16 --builder $BUILDER_IMAGE --network host -v
+          pack build $CONTAINER_IMAGE --path ./nodejs-rest-http --env BP_NODE_VERSION="~16" --builder $BUILDER_IMAGE --network host -v
           
           echo "Run the nodejs http application & tst ..."
           .github/testNodeHello.sh $CONTAINER_NAME $CONTAINER_IMAGE

--- a/.github/workflows/quarkus.yaml
+++ b/.github/workflows/quarkus.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '*.adoc'        # Ignores .adoc files at the root of the repository
+      - '*.md'          # Ignores .md files at the root of the repository
+      - '**/*.md'       # Ignores .md files within subdirectories
 jobs:
   linux-jvm-build:
     name: Linux - JVM build

--- a/.github/workflows/quarkus.yaml
+++ b/.github/workflows/quarkus.yaml
@@ -7,7 +7,6 @@ on:
       - main
 jobs:
   linux-jvm-build:
-    if: contains(github.event.head_commit.message, 'quarkus_test')
     name: Linux - JVM build
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/quarkus.yaml
+++ b/.github/workflows/quarkus.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         java: [ 17 ]
-        builder-image: [ 'paketobuildpacks/builder:tiny' ]
+        builder-image: [ 'paketobuildpacks/builder-jammy-tiny:0.0.175' ]
     steps:
       - uses: actions/checkout@v3
       - name: Install JDK ${{ matrix.java }}

--- a/.github/workflows/shipwright.yaml
+++ b/.github/workflows/shipwright.yaml
@@ -69,11 +69,7 @@ jobs:
               - name: CNB_BUILDER_IMAGE
                 value: paketobuildpacks/builder-jammy-tiny:0.0.175
               - name: CNB_LIFECYCLE_IMAGE
-<<<<<<< HEAD
                 value: buildpacksio/lifecycle:0.17.0
-=======
-                value: buildpacksio/lifecycle:0.16.5
->>>>>>> main
               - name: RUN_IMAGE
                 value: paketobuildpacks/run-jammy-tiny:latest
               - name: APP_IMAGE

--- a/.github/workflows/shipwright.yaml
+++ b/.github/workflows/shipwright.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '*.adoc'        # Ignores .adoc files at the root of the repository
+      - '*.md'          # Ignores .md files at the root of the repository
+      - '**/*.md'       # Ignores .md files within subdirectories
 jobs:
   linux-shipwright-build:
     name: Linux - Shipwright build

--- a/.github/workflows/shipwright.yaml
+++ b/.github/workflows/shipwright.yaml
@@ -7,7 +7,6 @@ on:
       - main
 jobs:
   linux-shipwright-build:
-    if: contains(github.event.head_commit.message, 'shipwright_test')
     name: Linux - Shipwright build
     runs-on: ubuntu-latest
     strategy:
@@ -16,9 +15,9 @@ jobs:
         tekton-version: [ 'v0.48.0' ]
         shipwright-version: [ 'v0.11.0' ]
         tekton-client-version: [ '0.31.0']
-        builder-image: [ 'paketobuildpacks/builder:0.1.361-tiny' ]
-        lifecycle-image: [ 'buildpacksio/lifecycle:0.16.3' ]
-        run-image: [ 'paketobuildpacks/run:tiny' ]
+        builder-image: [ 'paketobuildpacks/builder-jammy-tiny:0.0.175' ]
+        lifecycle-image: [ 'buildpacksio/lifecycle:0.17.0' ]
+        run-image: [ 'paketobuildpacks/run-jammy-tiny:latest' ]
     steps:
       - uses: actions/checkout@v3
       - name: Install JDK ${{ matrix.java }}
@@ -64,11 +63,11 @@ jobs:
               - name: CNB_PLATFORM_API
                 value: "0.11"
               - name: CNB_BUILDER_IMAGE
-                value: paketobuildpacks/builder:0.1.361-tiny
+                value: paketobuildpacks/builder-jammy-tiny:0.0.175
               - name: CNB_LIFECYCLE_IMAGE
-                value: buildpacksio/lifecycle:0.16.3
+                value: buildpacksio/lifecycle:0.17.0
               - name: RUN_IMAGE
-                value: paketobuildpacks/run:tiny
+                value: paketobuildpacks/run-jammy-tiny:latest
               - name: APP_IMAGE
                 value: ${CONTAINER_IMAGE}
               - name: PROCESS_TYPE

--- a/.github/workflows/tekton.yaml
+++ b/.github/workflows/tekton.yaml
@@ -7,7 +7,6 @@ on:
       - main
 jobs:
   linux-tekton-build:
-    if: contains(github.event.head_commit.message, 'tekton_test')
     name: Linux - Tekton build
     runs-on: ubuntu-latest
     strategy:
@@ -15,9 +14,9 @@ jobs:
         java: [ 17 ]
         tekton-version: [ 'v0.48.0' ]
         tekton-client-version: [ '0.31.0']
-        builder-image: [ 'paketobuildpacks/builder:0.1.361-tiny' ]
-        lifecycle-image: [ 'buildpacksio/lifecycle:0.16.3' ]
-        run-image: [ 'paketobuildpacks/run:tiny' ]
+        builder-image: [ 'paketobuildpacks/builder-jammy-tiny:0.0.175' ]
+        lifecycle-image: [ 'buildpacksio/lifecycle:0.17.0' ]
+        run-image: [ 'paketobuildpacks/run-jammy-tiny:latest' ]
     steps:
       - uses: actions/checkout@v3
       - name: Install JDK ${{ matrix.java }}

--- a/.github/workflows/tekton.yaml
+++ b/.github/workflows/tekton.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '*.adoc'        # Ignores .adoc files at the root of the repository
+      - '*.md'          # Ignores .md files at the root of the repository
+      - '**/*.md'       # Ignores .md files within subdirectories
 jobs:
   linux-tekton-build:
     name: Linux - Tekton build

--- a/README.adoc
+++ b/README.adoc
@@ -296,7 +296,7 @@ docker run -i --rm -p 8080:8080 kind-registry.local:5000/quarkus-hello
 
 == 4. RHTAP
 
-== Prerequisite
+=== Prerequisite
 
 - Have https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/getting-started/get-started/[access] to RHTAP - https://console.redhat.com/preview/hac/
 - Have kubectl (or oc client) installed on your machine
@@ -304,7 +304,7 @@ docker run -i --rm -p 8080:8080 kind-registry.local:5000/quarkus-hello
 - Add the `AppStudio` GitHub application to your GitHub Org and select it to be used for all the repositories. More information is available https://pipelinesascode.com/docs/install/github_apps/[here].
 - (optional). https://tekton.dev/docs/cli/[Install] the Tekton client
 
-== Env variables
+=== Env variables
 
 In order to play/execute the commands defined hereafter, it is needed to define some env variables.
 Feel free to change them according to your GitHub organisation, tenant namespace, etc
@@ -326,7 +326,7 @@ REGISTRY_URL=quay.io/redhat-user-workloads/$TENANT_NAMESPACE/$GITHUB_REPO_DEMO_N
 BUILD_ID=1 # ID used to generate the following kubernetes label's value: test-01 for rhtap.snowdrop.deb/build
 ----
 
-== HowTo
+=== HowTo
 
 To create a new GitHub repository and import the needed files, perform the following actions:
 
@@ -447,13 +447,13 @@ for entity in pods deployments routes services taskruns pipelineruns application
 kubectl delete application/$GITHUB_REPO_DEMO_NAME
 ----
 
-== Todo
+=== Todo
 
 - Try to make a test using our own quay.io credentials and repository using REGISTRY_URL=quay.io/$GITHUB_ORG_NAME
 
-== Issue
+=== Issue
 
-=== Full image path not supported
+==== Full image path not supported
 
 The lifecycle component and most probably google container library (used by lifecycle to access the registry) do not support such advanced feature: https://kubernetes.io/docs/concepts/containers/images/#kubelet-credential-provider
 The consequence is that if several secrets are attached to the `appstudio-pipeline` service account and subsequently by the pod running lifecycle, then

--- a/README.adoc
+++ b/README.adoc
@@ -190,13 +190,13 @@ The https://hub.docker.com/r/paketobuildpacks/builder/tags[paketo builder image]
 [,text]
 ----
 Lifecycle:
-  Version: 0.16.3
+  Version: 0.17.0
   Buildpack APIs:
     Deprecated: 0.2, 0.3, 0.4, 0.5, 0.6
-    Supported: 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9
+    Supported: 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10
   Platform APIs:
     Deprecated: 0.3, 0.4, 0.5, 0.6
-    Supported: 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 0.11
+    Supported: 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12
 ----
 
 It is time to create a `Pipelinerun` to build the Quarkus application
@@ -204,9 +204,9 @@ It is time to create a `Pipelinerun` to build the Quarkus application
 [,bash]
 ----
 IMAGE_NAME=kind-registry.local:5000/quarkus-hello
-BUILDER_IMAGE=paketobuildpacks/builder:0.1.361-tiny
-LIFECYCLE_IMAGE=buildpacksio/lifecycle:0.16.3
-RUN_IMAGE=paketobuildpacks/run:tiny
+BUILDER_IMAGE=paketobuildpacks/builder-jammy-tiny:0.0.175
+LIFECYCLE_IMAGE=buildpacksio/lifecycle:0.17.0
+RUN_IMAGE=paketobuildpacks/run-jammy-tiny:latest
 
 kubectl delete task/buildpacks-phases
 kubectl delete PipelineRun/buildpacks-phases

--- a/README.adoc
+++ b/README.adoc
@@ -59,14 +59,14 @@ Add first the following Quarkus extension to the Quarkus Getting started example
 quarkus extension add 'container-image-buildpack'
 ----
 
-Do the build using as builder image `paketobuildpacks/builder:tiny` and where you pass the needed `+BP_***+` env variables in order to configure
+Do the build using as builder image `paketobuildpacks/builder-jammy-tiny:0.0.175` and where you pass the needed `+BP_***+` env variables in order to configure
 properly the Quarkus mavn build:
 
 [,bash]
 ----
 mvn package \
  -Dquarkus.container-image.image=kind-registry.local:5000/quarkus-hello:1.0 \
- -Dquarkus.buildpack.jvm-builder-image=paketobuildpacks/builder:tiny \
+ -Dquarkus.buildpack.jvm-builder-image=paketobuildpacks/builder-jammy-tiny:0.0.175 \
  -Dquarkus.buildpack.builder-env.BP_NATIVE_IMAGE="false" \
  -Dquarkus.buildpack.builder-env.BP_MAVEN_BUILT_ARTIFACT="target/quarkus-app/lib/ target/quarkus-app/*.jar target/quarkus-app/app/ target/quarkus-app/quarkus/" \
  -Dquarkus.buildpack.builder-env.BP_MAVEN_BUILD_ARGUMENTS="package -DskipTests=true -Dmaven.javadoc.skip=true -Dquarkus.package.type=fast-jar" \
@@ -97,7 +97,7 @@ For that purpose, we use some build-time environment variables `-e` to configure
 REGISTRY_HOST="kind-registry.local:5000"
 docker rmi ${REGISTRY_HOST}/quarkus-hello:1.0
 pack build ${REGISTRY_HOST}/quarkus-hello:1.0 \
-     --builder paketobuildpacks/builder:tiny \
+     --builder paketobuildpacks/builder-jammy-tiny:0.0.175 \
      -e BP_NATIVE_IMAGE="false" \
      -e BP_MAVEN_BUILT_ARTIFACT="target/quarkus-app/lib/ target/quarkus-app/*.jar target/quarkus-app/app/ target/quarkus-app/quarkus/" \
      -e BP_MAVEN_BUILD_ARGUMENTS="package -DskipTests=true -Dmaven.javadoc.skip=true -Dquarkus.package.type=fast-jar" \

--- a/k8s/shipwright/secured/clusterbuildstrategy.yml
+++ b/k8s/shipwright/secured/clusterbuildstrategy.yml
@@ -199,7 +199,8 @@ spec:
       image: $(params.CNB_BUILDER_IMAGE)
       imagePullPolicy: Always
       securityContext:
-        runAsUser: 1000
+        # Update the user id to use new paketo builder
+        runAsUser: 1001
         runAsGroup: 1000
       command: ["/cnb/lifecycle/builder"]
       args:

--- a/k8s/shipwright/secured/clusterbuildstrategy.yml
+++ b/k8s/shipwright/secured/clusterbuildstrategy.yml
@@ -53,9 +53,10 @@ spec:
     - name: PLATFORM_DIR
       description: The name of the platform directory.
       default: empty-dir
-    - name: USER_ID
+    - # Update the user id to use new paketo builder image till we can use: https://github.com/shipwright-io/community/blob/main/ships/0036-runAs-for-supporting-steps.md
+      name: USER_ID
       description: The user ID of the builder image user.
-      default: "1000"
+      default: "1001"
     - name: GROUP_ID
       description: The group ID of the builder image user.
       default: "1000"
@@ -199,9 +200,8 @@ spec:
       image: $(params.CNB_BUILDER_IMAGE)
       imagePullPolicy: Always
       securityContext:
-        # Update the user id to use new paketo builder
-        runAsUser: 1001
-        runAsGroup: 1000
+        runAsUser: $(params.USER_ID)
+        runAsGroup: $(params.GROUP_ID)
       command: ["/cnb/lifecycle/builder"]
       args:
         - "-app=$(workspaces.source.path)/$(params.SOURCE_SUBPATH)"

--- a/k8s/shipwright/secured/clusterbuildstrategy.yml
+++ b/k8s/shipwright/secured/clusterbuildstrategy.yml
@@ -200,8 +200,8 @@ spec:
       image: $(params.CNB_BUILDER_IMAGE)
       imagePullPolicy: Always
       securityContext:
-        runAsUser: $(params.USER_ID)
-        runAsGroup: $(params.GROUP_ID)
+        runAsUser: 1001 # Won't work : $(params.USER_ID) -> https://github.com/shipwright-io/build/issues/1354
+        runAsGroup: 1000 # Won't work : $(params.GROUP_ID) -> https://github.com/shipwright-io/build/issues/1354
       command: ["/cnb/lifecycle/builder"]
       args:
         - "-app=$(workspaces.source.path)/$(params.SOURCE_SUBPATH)"
@@ -234,6 +234,7 @@ spec:
         requests:
           cpu: 250m
           memory: 65Mi
+
     - name: export
       image: $(params.CNB_LIFECYCLE_IMAGE)
       imagePullPolicy: Always
@@ -261,6 +262,7 @@ spec:
         - mountPath: /selfsigned-certificates
           name: certificate-registry
           readOnly: true
+
     - name: results
       image: docker.io/library/bash:5.1.4
       args:

--- a/k8s/shipwright/unsecured/build.yml
+++ b/k8s/shipwright/unsecured/build.yml
@@ -14,11 +14,11 @@ spec:
     - name: CNB_PLATFORM_API
       value: "0.11"
     - name: CNB_BUILDER_IMAGE
-      value: paketobuildpacks/builder:0.1.361-tiny
+      value: paketobuildpacks/builder-jammy-tiny:0.0.175
     - name: CNB_LIFECYCLE_IMAGE
-      value: buildpacksio/lifecycle:0.16.3
+      value: buildpacksio/lifecycle:0.17.0
     - name: RUN_IMAGE
-      value: paketobuildpacks/run:tiny
+      value: paketobuildpacks/run-jammy-tiny:latest
     - name: APP_IMAGE
       value: kind-registry.local:5000/quarkus-hello
     - name: PROCESS_TYPE

--- a/k8s/shipwright/unsecured/clusterbuildstrategy.yml
+++ b/k8s/shipwright/unsecured/clusterbuildstrategy.yml
@@ -181,8 +181,8 @@ spec:
       image: $(params.CNB_BUILDER_IMAGE)
       imagePullPolicy: Always
       securityContext:
-        runAsUser: $(params.USER_ID)
-        runAsGroup: $(params.GROUP_ID)
+        runAsUser: 1001 # Won't work : $(params.USER_ID) -> https://github.com/shipwright-io/build/issues/1354
+        runAsGroup: 1000 # Won't work : $(params.GROUP_ID) -> https://github.com/shipwright-io/build/issues/1354
       command: ["/cnb/lifecycle/builder"]
       args:
         - "-app=$(workspaces.source.path)/$(params.SOURCE_SUBPATH)"

--- a/k8s/shipwright/unsecured/clusterbuildstrategy.yml
+++ b/k8s/shipwright/unsecured/clusterbuildstrategy.yml
@@ -46,9 +46,10 @@ spec:
     - name: PLATFORM_DIR
       description: The name of the platform directory.
       default: empty-dir
-    - name: USER_ID
+    - # Update the user id to use new paketo builder image till we can use: https://github.com/shipwright-io/community/blob/main/ships/0036-runAs-for-supporting-steps.md
+      name: USER_ID
       description: The user ID of the builder image user.
-      default: "1000"
+      default: "1001"
     - name: GROUP_ID
       description: The group ID of the builder image user.
       default: "1000"
@@ -180,9 +181,8 @@ spec:
       image: $(params.CNB_BUILDER_IMAGE)
       imagePullPolicy: Always
       securityContext:
-        # Update the user id to use new paketo builder
-        runAsUser: 1001
-        runAsGroup: 1000
+        runAsUser: $(params.USER_ID)
+        runAsGroup: $(params.GROUP_ID)
       command: ["/cnb/lifecycle/builder"]
       args:
         - "-app=$(workspaces.source.path)/$(params.SOURCE_SUBPATH)"

--- a/k8s/shipwright/unsecured/clusterbuildstrategy.yml
+++ b/k8s/shipwright/unsecured/clusterbuildstrategy.yml
@@ -180,7 +180,8 @@ spec:
       image: $(params.CNB_BUILDER_IMAGE)
       imagePullPolicy: Always
       securityContext:
-        runAsUser: 1000
+        # Update the user id to use new paketo builder
+        runAsUser: 1001
         runAsGroup: 1000
       command: ["/cnb/lifecycle/builder"]
       args:

--- a/k8s/shipwright/unsecured/clusterbuildstrategy.yml
+++ b/k8s/shipwright/unsecured/clusterbuildstrategy.yml
@@ -15,13 +15,13 @@ spec:
   parameters:
     - name: CNB_PLATFORM_API
       description: Platform API Version supported
-      default: "0.10"
+      default: "0.12"
     - name: CNB_BUILDER_IMAGE
       description: Builder image containing the buildpacks
       default: ""
     - name: CNB_LIFECYCLE_IMAGE
       description: The image to use when executing Lifecycle phases.
-      default: "docker.io/buildpacksio/lifecycle:0.10.2@sha256:1bf8d3fc41d2fdf0ee4abdad50038ab8902ef58c74f5bcfc432c26767d889ed0"
+      default: "docker.io/buildpacksio/lifecycle:0.17.0@sha256:a55d870a2c026228aeddd999a4efe290122aab33b5afc1dd15c7780db2f61d90"
     - name: APP_IMAGE
       description: The name of where to store the app image.
     - name: RUN_IMAGE

--- a/k8s/tekton/buildpacks-phases.yml
+++ b/k8s/tekton/buildpacks-phases.yml
@@ -34,7 +34,7 @@ spec:
       description: The name of where to store the app image.
     - name: RUN_IMAGE
       description: Reference to a run image to use.
-      default: "paketobuildpacks/run:tiny"
+      default: "paketobuildpacks/run-jammy-tiny:latest"
     - name: CACHE_IMAGE
       description: The name of the persistent app cache image (if no cache workspace is provided).
       default: ""
@@ -53,7 +53,7 @@ spec:
       default: empty-dir
     - name: USER_ID
       description: The user ID of the builder image user.
-      default: "1000"
+      default: "1001"
     - name: GROUP_ID
       description: The group ID of the builder image user.
       default: "1000"
@@ -70,7 +70,7 @@ spec:
   stepTemplate:
     env:
       - name: CNB_PLATFORM_API
-        value: "0.10"
+        value: "0.12"
       - name: HOME
         value: $(params.USER_HOME)
 
@@ -204,7 +204,6 @@ spec:
         - "-process-type=$(params.PROCESS_TYPE)"
         - "-uid=$(params.USER_ID)"
         - "-gid=$(params.GROUP_ID)"
-        - "-stack=/layers/stack.toml"
         - "$(params.APP_IMAGE)"
       volumeMounts:
         - name: layers-dir


### PR DESCRIPTION
- Issue #25 
- Bump version of lifecycle to 0.17.0, pack cli: 0.30.0-rc1 
- Removed -stack=/layers/stack.toml from export phase as non supported.
- Removed the if conditions from githubactions. 
- Aligned images of paketo builder to use also lifecycle 0.17 for platform 0.12