### PR TITLE
Fixes to Shipwright Build Strategy

### DIFF
--- a/.github/workflows/shipwright.yaml
+++ b/.github/workflows/shipwright.yaml
@@ -116,6 +116,13 @@ jobs:
               kind: ClusterBuildStrategy
             output:
               image: $CONTAINER_IMAGE
+            volumes:
+              - name: certificate-registry
+                configMap:
+                  name: certificate-registry
+              - name: creds-ws
+                secret:
+                  secretName: dockercfg
           EOF
           kubectl create -f $GITHUB_WORKSPACE/k8s/shipwright/buildrun.yml
 
@@ -137,11 +144,11 @@ jobs:
           kubectl get buildrun -A
 
           echo "BuildRun describe resource"
-          BUILDRUN_NAME=$(kubectl get buildrun -lbuild.shipwright.io/name=buildpack-quarkus-build -oname)
+          BUILDRUN_NAME=$(kubectl get buildrun -l build.shipwright.io/name=buildpack-quarkus-build -o name)
           kubectl describe $BUILDRUN_NAME
 
       - name: Print Log of the buildrun
         if: failure()
         run: |
-          POD_NAME=$(kubectl get pod -lbuild.shipwright.io/name=buildpack-quarkus-build -oname)
+          POD_NAME=$(kubectl get pod -l build.shipwright.io/name=buildpack-quarkus-build -o name)
           kubectl logs $POD_NAME --all-containers

--- a/k8s/shipwright/build.yml
+++ b/k8s/shipwright/build.yml
@@ -38,5 +38,12 @@ spec:
   strategy:
     name: buildpacks
     kind: ClusterBuildStrategy
+  volumes:
+    - name: certificate-registry
+      configMap:
+        name: certificate-registry
+    - name: creds-ws
+      secret:
+        secretName: dockercfg
   output:
     image: my-gitea-http.gitea.svc.cluster.local:3000/giteaadmin/quarkus-hello:latest

--- a/k8s/shipwright/clusterbuildstrategy.yml
+++ b/k8s/shipwright/clusterbuildstrategy.yml
@@ -5,11 +5,11 @@ metadata:
 spec:
   volumes:
     - name: certificate-registry
-      configMap:
-        name: certificate-registry
+      emptyDir: {}
+      overridable: true
     - name: creds-ws
-      secret:
-        secretName: dockercfg
+      emptyDir: {}
+      overridable: true
     - name: kaniko-dir
       emptyDir: {}
     - name: platform-env

--- a/k8s/shipwright/clusterbuildstrategy.yml
+++ b/k8s/shipwright/clusterbuildstrategy.yml
@@ -89,7 +89,8 @@ spec:
       default: "-Dmaven.test.skip=true --no-transfer-progress package"
   steps:
     - name: prepare
-      image: docker.io/library/bash:5.1.4
+      image: registry.access.redhat.com/ubi9/ubi-minimal:9.6
+      command: ["/bin/bash"]
       args:
         - -c
         - |
@@ -276,7 +277,8 @@ spec:
           readOnly: true
 
     - name: results
-      image: docker.io/library/bash:5.1.4
+      image: registry.access.redhat.com/ubi9/ubi-minimal:9.6
+      command: ["/bin/bash"]
       args:
         - -c
         - |


### PR DESCRIPTION
- Use UBI Buildpacks
- Set certs and credentials volumes to be `emptyDir` and overridable by default.